### PR TITLE
Fix coin tokens going negative (kinda)

### DIFF
--- a/web/static/logprettifier.html
+++ b/web/static/logprettifier.html
@@ -452,6 +452,8 @@ function updateDeck(player, action) {
 	updateCards(player, []);
     } else if (h = action.match(/^uses ([0-9]*) coin token[s]?$/)) {
 	cointokens[player]-=+h[1];
+	if(cointokens[player] < 0)
+		cointokens[player] = 0 ;
 	updateCards(player, []);
     } else if (h = action.match(/^plays Bishop$/)) {
 	vpchips[player]++;


### PR DESCRIPTION
The issue is actually in the log we get from goko.  For example, in turn 15b in this game:
http://dominionlogs.goko.com//20150313/log.50fd569ae4b0f82020d83fac.1426262278949.txt

Jeebus has one coin token from a previous turn and then plays the following:

Jeebus - duration Caravan
Jeebus - draws Mercenary
Jeebus - plays Baker
Jeebus - receives 1 coin token
Jeebus - draws Spoils
Jeebus - plays Caravan
Jeebus - draws Spoils
Jeebus - uses 2 coin tokens
Jeebus - plays Spoils
Jeebus - uses 2 coin tokens
Jeebus - plays Spoils
Jeebus - uses 2 coin tokens


So when it came to the buy phase, Jeebus only had 2 coin tokens.  He used them, but the goko log says then used them again after the two "plays Spoils"... in effect saying he spent them 3 times.  Our counter decrements each time it encounters "uses 2 coin tokens" so our counter then showed -4 coin tokens.

My code change here does not fix the issue with Goko relaying 3 "uses coins" instead of one.  (Because we can't fix that.)  However, it does add a check that coin tokens can't go below zero... which, solves the issue this time... but leaves the following edge case:

- Same situation as above, but Jeebus uses only 1 coin, intending to save 1 for another turn
- The Goko log reports that 3 times... 
- Our coin tracker says he has 0 coins left instead of carrying 1 over to the next turn... which isn't accurate.

But how could we solve that one on our end?  A player could legitimately "use a coin token" "play a Spoils" and "use another coin token" and we have no way of determining whether that's what he actually did, or Goko gave us a bad log.